### PR TITLE
Flush stdout when requesting input

### DIFF
--- a/src/scriptlike/interact.d
+++ b/src/scriptlike/interact.d
@@ -62,6 +62,7 @@ import std.traits;
 T userInput(T = string)(string question = "")
 {
 	write(question ~ "\n> ");
+	stdout.flush;
 	auto ans = readln();
 
 	static if(is(T == bool))


### PR DESCRIPTION
Not all terminals display the output written to them at the time input is requested. This will force the question to be written to the screen.