### PR TITLE
Add equivalents of Powershell's Push-Location and Pop-Location

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Sections
 * [Command Echoing](#command-echoing)
 * [Dry Run Assistance](#dry-run-assistance)
 * [Fail](#fail)
+* [Directory Change Stack](#directory-change-stack)
 
 **[Disambiguating write and write](#disambiguating-write-and-write)**
 
@@ -378,6 +379,30 @@ void helper(string[] args) {
 See: [```fail```](http://semitwist.com/scriptlike/scriptlike/fail/fail.html),
 [```failEnforce```](http://semitwist.com/scriptlike/scriptlike/fail/failEnforce.html),
 [```Fail```](http://semitwist.com/scriptlike/scriptlike/fail/Fail.html)
+
+### Directory Change Stack
+
+Push the current directory onto a stack every time you change directory, 
+then easily restore the original location(s) as needed.
+
+```d
+// Move into a subdirectory and do some work, 
+// then easily move back into the old directory!
+tryPushDir("dir1");
+/* tryRun... tryCopy.. etc.*/
+tryPopDir();
+
+// Since it's stack based, you can push and pop freely.
+tryPushDir("dir1"); // ./dir1
+tryPushDir("dir2"); // ./dir1/dir2
+popDirRecurse();    // ./
+```
+
+See: [```tryPushDir```](http://semitwist.com/scriptlike/scriptlike/file/extras/tryPushDir.html),
+[```pushDir```](http://semitwist.com/scriptlike/scriptlike/file/extras/pushDir.html),
+[```tryPopDir```](http://semitwist.com/scriptlike/scriptlike/file/extras/tryPopDir.html),
+[```popDir```](http://semitwist.com/scriptlike/scriptlike/file/extras/popDir.html),
+[```popDirRecurse```](http://semitwist.com/scriptlike/scriptlike/file/extras/popDirRecurse.html)
 
 Disambiguating write and write
 ------------------------------

--- a/examples/features/DirectoryChangeStack.d
+++ b/examples/features/DirectoryChangeStack.d
@@ -1,0 +1,24 @@
+import scriptlike;
+
+void main()
+{
+	// Setup and cleanup
+	chdir(thisExePath.dirName);
+	scope(exit)
+	{
+		scriptlikeEcho = false;
+		tryRmdirRecurse("dir1");
+	}
+    tryMkdirRecurse("dir1/dir2");
+
+    // Move into a subdirectory and do some work, 
+    // then easily move back into the old directory!
+    tryPushDir("dir1");
+    /* tryRun... tryCopy.. etc.*/
+    tryPopDir();
+
+    // Since it's stack based, you can push and pop freely.
+    tryPushDir("dir1"); // ./dir1
+    tryPushDir("dir2"); // ./dir1/dir2
+    popDirRecurse();    // ./
+}

--- a/tests/testExample.d
+++ b/tests/testExample.d
@@ -15,6 +15,7 @@ void main(string[] args)
 
 		"features/AutomaticPhobosImport":     &testAutomaticPhobosImport,
 		"features/CommandEchoing":            &testCommandEchoing,
+        "features/DirectoryChangeStack":      &testDirectoryChangeStack,
 		"features/DisambiguatingWrite":       &testDisambiguatingWrite,
 		"features/DryRunAssistance":          &testDryRunAssistance,
 		"features/Fail":                      &testFail,
@@ -437,4 +438,10 @@ void testSingleFile()
 		"dub --vquiet --single "~getDubEnvArgs~" "~Path("../../examples/single-file/myscript.d").raw~" -- ",
 		false
 	);
+}
+
+void testDirectoryChangeStack()
+{
+    auto output = compileAndRun(testName).normalizeNewlines;
+	assert(output == "");
 }


### PR DESCRIPTION
This does use thread-local global state to store the directory stack, but I'm uncertain how many scripts out there change directory in multiple different threads.

This PR is slightly for my own selfish needs, since I include a function like this in a lot of my scripts >:3